### PR TITLE
Add Slice Definition

### DIFF
--- a/cmake/gtest.cmake
+++ b/cmake/gtest.cmake
@@ -1,9 +1,9 @@
-cmake_policy(SET CMP0135 NEW)
 include(FetchContent)
 FetchContent_Declare(
   googletest
   # Specify the commit you depend on and update it regularly.
   URL https://github.com/google/googletest/archive/5376968f6948923e2411081fd9372e71a59d8e77.zip
+  DOWNLOAD_EXTRACT_TIMESTAMP true
 )
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)

--- a/db/CMakeLists.txt
+++ b/db/CMakeLists.txt
@@ -2,4 +2,9 @@ add_library(art_static STATIC
     art.cpp
     art.hpp
 )
+add_library(art_shared SHARED
+    art.cpp
+    art.hpp
+)
 target_include_directories(art_static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(art_shared PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/db/art.hpp
+++ b/db/art.hpp
@@ -1,6 +1,4 @@
-#ifndef __ART_HPP__
-#define __ART_HPP__
-
+#pragma once
 #include <array>
 #include <atomic>
 #include <cstddef>
@@ -8,13 +6,15 @@
 #include <memory>
 #include <optional>
 #include <span>
+#include <string_view>
 #include <sys/types.h>
 #include <vector>
 
+#include "slice.hpp"
+
 namespace art {
 
-using ARTDataRef = std::span<const unsigned char>;
-using ARTData = std::vector<unsigned char>;
+using ARTData = std::vector<uint8_t>;
 enum class NodeType : uint8_t { Node4, Node16, Node48, Node256, Leaf };
 inline constexpr size_t MAX_PARTIAL_LEN = 10;
 
@@ -159,7 +159,7 @@ public:
    * @param value value The value to associate with the key, which is a byte
    * stream. This value is moved into the tree.
    */
-  void insert(ARTDataRef key, ARTData &&value);
+  void insert(Slice key, OwnedSlice value);
 
   /**
    * Searches for a value associated with a given key in the ART.
@@ -168,7 +168,7 @@ public:
    * the object to a byte stream
    * @return std::optional<ARTDataRef>
    */
-  std::optional<ARTDataRef> search(ARTDataRef key);
+  std::optional<std::span<uint8_t>> search(Slice key);
 
   /**
    * Removes a key-value pair from the ART, identified by the key.
@@ -176,7 +176,7 @@ public:
    * @param key The key of the pair to remove. Before using it, you should
    * convert the object to a byte stream
    */
-  void remove(ARTDataRef key);
+  void remove(Slice key);
 
   /**
    * Returns the tree size.
@@ -187,10 +187,9 @@ private:
   NodeRef root;
   size_t tree_size;
 
-  void insertRecursively(NodeRef node, ARTDataRef key, LeafNode leaf, int depth);
+  void insertRecursively(NodeRef node, std::span<uint8_t> key, LeafNode leaf, int depth);
   static void replace(NodeRef& node, Node* newNode);
 };
 
 } // namespace art
 
-#endif

--- a/db/slice.hpp
+++ b/db/slice.hpp
@@ -1,0 +1,148 @@
+#pragma once
+
+#include <concepts>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <string>
+#include <string_view>
+#include <sys/types.h>
+namespace art{
+
+
+template<typename T>
+concept SliceTrait = requires(T t){
+    {t.data()} -> std::convertible_to<const uint8_t*>;
+    {t.begin()} -> std::convertible_to<const uint8_t*>;
+    {t.end()} -> std::convertible_to<const uint8_t*>;
+    {t.ToString()} -> std::convertible_to<std::string_view>;
+    {t.ToHexString()} -> std::convertible_to<std::string>;
+    {t.size()} -> std::convertible_to<std::ptrdiff_t>;
+};
+
+class Slice{
+private:
+    const uint8_t *data_;
+    std::ptrdiff_t len_;
+public:
+    Slice(const uint8_t* data, std::ptrdiff_t len):data_(data), len_(len){}
+    Slice(const int8_t* data, std::ptrdiff_t len):data_(reinterpret_cast<const uint8_t*>(data)), len_(len){}
+    Slice(const std::string_view s):data_(reinterpret_cast<const uint8_t*>(s.data())), len_(s.length()){}
+
+    template<size_t N>
+    Slice(const uint8_t (&a)[N]):data_(reinterpret_cast<const uint8_t*>(a)), len_(N){}
+    
+    template<size_t N>
+    Slice(const int8_t (&a)[N]):data_(reinterpret_cast<const uint8_t*>(a)), len_(N){}
+    
+    template<size_t N>
+    Slice(const char (&a)[N]):data_(reinterpret_cast<const uint8_t*>(a)), len_(N){}
+
+    uint8_t operator[](size_t n) const {return data_[n];}
+    uint8_t* data() const {return const_cast<uint8_t*>(data_);}
+    std::ptrdiff_t size() const {return len_;}
+    std::ptrdiff_t length() const {return len_;}
+    bool empty() const {return len_ == 0;}
+
+    const uint8_t* begin() const {return const_cast<uint8_t*>(data_);}
+    const uint8_t* end() const {return const_cast<uint8_t*>(data_ + len_);}
+
+    std::span<uint8_t> as_span() const {return std::span<uint8_t>(const_cast<uint8_t*>(data_), len_);}
+
+    std::string_view ToString() const {return std::string_view(reinterpret_cast<const char*>(data_), len_);}
+    std::string ToHexString() const {
+        std::string s;
+        s.reserve(len_ * 2);
+        for (size_t i = 0; i < len_; i++){
+            char buf[3];
+            snprintf(buf, sizeof(buf), "%02x", data_[i]);
+            s.append(buf);
+        }
+        return s;
+    }
+};
+// assert that Slice is SliceBase
+static_assert(SliceTrait<Slice>);
+
+class OwnedSlice{
+private:
+struct OwnedBase{
+    virtual ~OwnedBase() = default;
+    virtual uint8_t* data() = 0;
+    virtual std::ptrdiff_t size() const = 0;
+    virtual std::unique_ptr<OwnedBase> clone() const = 0;
+};
+
+template<std::ranges::contiguous_range T>
+struct Data : OwnedBase {
+    T data_;
+    Data(const T& t) : data_(t) {}
+    virtual std::unique_ptr<OwnedBase> clone() const override {
+        return std::make_unique<Data<T>>(data_);
+    }
+    virtual uint8_t* data() override {
+        return reinterpret_cast<uint8_t*>(data_.data());
+    }
+    virtual std::ptrdiff_t size() const override {
+        return data_.size();
+    }
+};
+std::unique_ptr<OwnedBase> owned_;
+
+template<typename T>
+T& get_data() {
+    return static_cast<Data<T>&>(*owned_).data;
+}
+
+public:
+template<std::ranges::contiguous_range T>
+OwnedSlice(T&& t) : owned_(std::make_unique<Data<T>>(std::move(t))) {}
+template<std::ranges::contiguous_range T>
+OwnedSlice(T& _) = delete;
+OwnedSlice(OwnedSlice&& rhs) noexcept {
+    owned_ = std::move(rhs.owned_);
+}
+OwnedSlice& operator=(OwnedSlice&& rhs) noexcept {
+    owned_ = std::move(rhs.owned_);
+    return *this;
+}
+OwnedSlice(const OwnedSlice& rhs) {
+    owned_ = rhs.owned_->clone();
+}
+OwnedSlice& operator=(const OwnedSlice& rhs) {
+    owned_ = rhs.owned_->clone();
+    return *this;
+}
+uint8_t* data(){
+    return owned_->data();
+}
+std::ptrdiff_t size() const {
+    return owned_->size();
+}
+std::string_view ToString() const {
+    return std::string_view(reinterpret_cast<const char*>(owned_->data()), owned_->size());
+}
+uint8_t* begin() const {
+    return owned_->data();
+}
+uint8_t* end() const {
+    return owned_->data() + owned_->size();
+}
+std::span<uint8_t> as_span() const {
+    return std::span<uint8_t>(owned_->data(), owned_->size());
+}
+std::string ToHexString() const {
+    std::string s;
+    s.reserve(owned_->size() * 2);
+    for (size_t i = 0; i < owned_->size(); i++){
+        char buf[3];
+        snprintf(buf, sizeof(buf), "%02x", owned_->data()[i]);
+        s.append(buf);
+    }
+    return s;
+}
+
+};
+static_assert(SliceTrait<OwnedSlice>);
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,3 +8,9 @@ add_executable(
     ${PROJECT_NAME}
     ${SOURCES}
 )
+
+target_include_directories(
+    ${PROJECT_NAME}
+    PUBLIC
+    ${CMAKE_SOURCE_DIR}/db
+)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,13 @@
 #include <iostream>
 #include <format>
+#include "slice.hpp"
+
+using namespace art;
+
 
 int main() {
     std::cout << "Hello, world!\n";
-    
+    auto value_left_value = std::string("abc");
+    auto slice = OwnedSlice(std::move(value_left_value));
     return 0;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 enable_testing()
 include(GoogleTest)
 add_executable(ut_test test.cpp)
-target_link_libraries(ut_test PRIVATE gtest gtest_main)
+target_link_libraries(ut_test PRIVATE gtest gtest_main art_shared)
 
 gtest_discover_tests(ut_test)

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,4 +1,9 @@
+#include <complex>
+#include <string>
 #include "gtest/gtest.h"
+#include "art.hpp"
+#include "slice.hpp"
+
 
 int main(int argc, char **argv) {
     testing::InitGoogleTest(&argc, argv);
@@ -8,4 +13,17 @@ int main(int argc, char **argv) {
 TEST(HelloWorld, BasicAssertions) {
     EXPECT_STRNE("hello", "world");
     EXPECT_EQ(7 * 6, 42);
+}
+
+using namespace art;
+using namespace std;
+
+TEST(Art, Add){
+    const char key[] = "hello";
+    const char value[] = "world";
+    
+    auto art = ART();
+    art.insert(key, std::string("world"));
+
+    art.search(key);
 }


### PR DESCRIPTION
It will make art more convenient to use.
First, the Slice can reference any continuous `uint8_t` container.
And OwnedSlice enables users to transfer the ownership of data exclusively to this container, thus preventing unnecessary memory copying.